### PR TITLE
enable default landing page for accessing with ip address

### DIFF
--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -22,6 +22,12 @@ services:
     environment:
       - "DEFAULT_EMAIL=my.email@test.email" # <--- please change to your email
 
+  landing-page:
+    image: nginxdemos/hello
+    environment:
+      - VIRTUAL_HOST=130.60.24.169
+      - VIRTUAL_PORT=80
+
 networks:
   default:
     external: true


### PR DESCRIPTION
fix #43 
remark
* lets encrypt cert cannot be assigned to ip address [source](https://community.letsencrypt.org/t/ssl-on-a-ip-instead-of-domain/90635/2)
